### PR TITLE
Fix for issues with date time picker

### DIFF
--- a/ux/DateTime.js
+++ b/ux/DateTime.js
@@ -127,7 +127,7 @@ Ext.define('Ext.ux.picker.DateTime', {
         for (i = 0; i < ln; i++) {
             item = items[i];
             if (item instanceof Ext.picker.Slot) {
-                values[item.getName()] = item.getValue();
+                values[item.getName()] = item.getValue(true);
             }
         }
         daysInMonth = this.getDaysInMonth(values.month, values.year);
@@ -251,7 +251,7 @@ Ext.define('Ext.ux.picker.DateTime', {
             daysInMonth;
 
         if(!this.getAmpm()){
-            var index = slotOrder.indexOf('ampm')
+            var index = slotOrder.indexOf('ampm');
             if(index >= 0){
                 slotOrder.splice(index);
             }
@@ -286,8 +286,8 @@ Ext.define('Ext.ux.picker.DateTime', {
             });
         }
 
-        var hourLimit =  (this.getAmpm()) ? 12 : 23
-        var hourStart =  (this.getAmpm()) ? 1 : 0
+        var hourLimit =  (this.getAmpm()) ? 12 : 23;
+        var hourStart =  (this.getAmpm()) ? 1 : 0;
         for(i=hourStart;i<=hourLimit;i++){
             hours.push({
                 text: this.pad2(i),
@@ -407,7 +407,7 @@ Ext.define('Ext.ux.picker.DateTime', {
         // Get the new days of the month for this new date
         daysInMonth = this.getDaysInMonth(month, year);
 
-        for (i = 0; i < daysInMonth; i++) {
+        for (var i = 0; i < daysInMonth; i++) {
             days.push({
                 text: i + 1,
                 value: i + 1

--- a/ux/DateTimePicker.js
+++ b/ux/DateTimePicker.js
@@ -306,8 +306,10 @@ Ext.define('Ext.ux.field.DateTimePicker', {
      * Revert internal date so field won't appear changed
      */
     onPickerCancel: function(picker, options) {
-        this._picker = this._picker.config;
-        picker.destroy();
+        if (this.getDestroyPickerOnHide() && picker) {
+            this._picker = this._picker.config;
+            picker.destroy();
+        }
         return true;
     },
     


### PR DESCRIPTION
I ran into a few problems with the date picker.

1) When you open the picker and press cancel it will destroy the picker because there isn't a code check in onPickerCancel. When you open it again there is nothing inside it.

2) When you press OK on the default date (1/1/1980 12:00am)  it doesn't read the information properly from the slot. Adding true to item.getValue fixes that.

3) Cleaned up missing ;
